### PR TITLE
feat(make): add Makefile for compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: all clean
+
+common_deps := csustThesis.cls baseinfo.tex reference.bib
+
+all: thesis.pdf research_proposal.pdf task_book.pdf translation.pdf
+
+thesis.pdf: thesis.tex ${common_deps}
+	xelatex thesis
+	biber thesis
+	xelatex thesis
+	xelatex thesis
+
+research_proposal.pdf: research_proposal.tex ${common_deps}
+	xelatex research_proposal
+	biber research_proposal
+	xelatex research_proposal
+	xelatex research_proposal
+
+task_book.pdf: task_book.tex ${common_deps}
+	xelatex task_book
+	biber task_book
+	xelatex task_book
+	xelatex task_book
+
+translation.pdf: translation.tex ${common_deps}
+	xelatex translation
+	biber translation
+	xelatex translation
+	xelatex translation
+
+slides/slides.pdf: slides/slides.tex
+	cd slides && xelatex slides && xelatex slides
+
+clean:
+	-rm *.aux *.bbl *.bcf *.blg *.lof *.log *.pdf *.run.xml *.toc slides/*.pdf


### PR DESCRIPTION
添加 Makefile 以方便 Linux 命令行用户。

Makefile 里的编译依赖可能不完整。

`make clean` 会删除 `*.pdf`，这样可以方便 clean compile，另外也建议将 PDF 文件都放在 Release 里，毕竟 `.gitignore` 里都忽略了 `*.pdf`。

我还计划添加 GitHub Actions 自动发布最新的模板 PDF。