### PR TITLE
fix(task_book): autofill supervisor name in task book

### DIFF
--- a/csustThesis.cls
+++ b/csustThesis.cls
@@ -593,7 +593,7 @@
         \makebox[\maxwidth][s]{学生姓名}\underline{\makebox[4.15cm][c]{\csustThesis@stuName}}
         \makebox[5.85cm][r]{\mbox{学\hspace{.5em}号}\underline{\makebox[4.15cm][c]{\csustThesis@stuID}}}
 
-        \makebox[\maxwidth][s]{指导教师}\underline{\makebox[4.15cm][c]{}}
+        \makebox[\maxwidth][s]{指导教师}\underline{\makebox[4.15cm][c]{\csustThesis@supervisorName}}
         \makebox[5.85cm][r]{}
 
         \makebox[\maxwidth][s]{教研室主任}\underline{\makebox[4.15cm][c]{}}


### PR DESCRIPTION
自动填写在 `baseinfo.tex` 里面定义的指导老师名字。

不知道这个要不要手写啊，需要手写的话可以在 `csustThesis.cls` 里加上注释。