### PR TITLE
更新 Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all release clean
 
 common_deps := csustThesis.cls baseinfo.tex reference.bib
+body_deps := body/*.tex
 
 all: thesis.pdf research_proposal.pdf task_book.pdf translation.pdf slides/slides.pdf
 
@@ -8,7 +9,7 @@ release: thesis.pdf research_proposal.pdf task_book.pdf translation.pdf slides/s
 	mkdir -p release
 	mv $^ release
 
-thesis.pdf: thesis.tex ${common_deps}
+thesis.pdf: thesis.tex ${common_deps} ${body_deps}
 	xelatex thesis
 	biber thesis
 	xelatex thesis

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
 
 common_deps := csustThesis.cls baseinfo.tex reference.bib
 body_deps := body/*.tex
+pdfs := thesis.pdf research_proposal.pdf task_book.pdf translation.pdf slides/slides.pdf
 
-all: thesis.pdf research_proposal.pdf task_book.pdf translation.pdf slides/slides.pdf
+all: ${pdfs}
 
-release: thesis.pdf research_proposal.pdf task_book.pdf translation.pdf slides/slides.pdf
+release: ${pdfs}
 	mkdir -p release
 	mv $^ release
 
@@ -41,3 +42,4 @@ clean:
 	-cd slides && rm -f *.aux *.log *.nav *.out *.snm *.toc
 	-rm -rf release
 	-rm -f body/*.aux
+	-rm -f ${pdfs}


### PR DESCRIPTION
- 添加了 thesis.pdf 缺失的 `body/*.tex` 依赖
- 只删除编译生成的 PDF 文件，不会删除 `初稿.pdf` 等被重命名的 PDF 文件

因为 Makefile 里的依赖并不是面面俱到的，像是图片之类的就没有添加到依赖里，这样的话如果这些文件更新了，执行 `make` 并不会重新编译，这时候就需要删除生成的 PDF 文件。我觉得有保留需求的人对这种解决方案也能接受。

讨论见 #5 