### PR TITLE
优化目录一级标题、公式标号、参考文献双斜杠问题

### DIFF
--- a/csustThesis.cls
+++ b/csustThesis.cls
@@ -26,7 +26,8 @@
 \RequirePackage{makecell}  % 表格线宽支持
 \RequirePackage{booktabs}  % 三线表支持
 \RequirePackage{bigstrut} %% 该宏包提供 \bigstrut 命令，可以增大表格的行间距
-\RequirePackage[backend=biber,style=gb7714-2015,gbnamefmt=lowercase,refsegment=part,defernumbers=true,gbtype=true,]{biblatex}  % 支持参考文献
+%使用 gbpuction=false和gbpub=false可以防止参考文献中出现//，具体问题可见：https://shorturl.at/deszM，双斜杠代表它之前的文献出自于双斜杠后的专著。但是学校要求不能出现//。
+\RequirePackage[backend=biber,style=gb7714-2015,gbnamefmt=lowercase,refsegment=part,defernumbers=true,gbtype=true,gbpunctin=false,gbpub=false]{biblatex}  % 支持参考文献
 \RequirePackage{emptypage} %% 此宏包负责的任务是当每一章最后一页是偶数页时，设置空白
 \RequirePackage{tikz}
 \RequirePackage{indentfirst}
@@ -36,6 +37,12 @@
 \RequirePackage{suffix}  % 定义 * 命令
 \RequirePackage{varwidth}  
 \RequirePackage{ulem}  % 删除线  
+\RequirePackage{pifont} % 用来显示 ①
+% 控制 ① 得字体大小 见：https://tex.stackexchange.com/a/130236
+\let\oldding\ding% Store old \ding in \oldding
+\renewcommand{\ding}[2][1]{\scalebox{#1}{\oldding{#2}}}% Scale \oldding via optional argument，默认大小1，一般1.3倍较合适。
+
+
 
 
 % Options
@@ -69,7 +76,7 @@
 \ctexset{
 	section = {  % 一级标题
 		format = \centering\heiti\zihao{-3},  % 黑体小三居中
-		name = {第, 章},
+		% name = {第, 章}, 实际上不需要第x章，直接编号即可。
 	},
 	subsection = {  % 二级标题
 		format = \heiti\zihao{4},  % 黑体四号
@@ -137,6 +144,8 @@
 % 图表名格式设置
 \captionsetup{font=small,labelsep=space}  % 图表标题设为五号字体、序号与图表名之间以空格分隔
 \captionsetup[table]{font={small,bf},labelsep=space}  % 表标题设为五号加粗、表序与表名之间以空格分隔
+% 公式按照一级标题开始编号 1.x 表示第一章里面得公式x
+\numberwithin{equation}{section} % 设置公式按照一级标题标号
 \counterwithin{figure}{section}  % 图按章节编号
 \counterwithin{table}{section}  % 表按章节编号
 \renewcommand{\thefigure}{\thesection.\arabic{figure}}  % 图几.几

--- a/csustThesis.cls
+++ b/csustThesis.cls
@@ -123,6 +123,7 @@
     }
     \renewcommand{\thefigure}{\thesection\arabic{figure}}  % 图几几
     \renewcommand{\thetable}{\thesection\arabic{table}}  % 表几几
+    \renewcommand{\theequation}{\thesection\arabic{equation}}  % 公式(Ax)
 }
 
 % 页眉页脚预设置
@@ -144,13 +145,13 @@
 % 图表名格式设置
 \captionsetup{font=small,labelsep=space}  % 图表标题设为五号字体、序号与图表名之间以空格分隔
 \captionsetup[table]{font={small,bf},labelsep=space}  % 表标题设为五号加粗、表序与表名之间以空格分隔
-% 公式按照一级标题开始编号 1.x 表示第一章里面得公式x
-\numberwithin{equation}{section} % 设置公式按照一级标题标号
 \counterwithin{figure}{section}  % 图按章节编号
 \counterwithin{table}{section}  % 表按章节编号
+\counterwithin{equation}{section} % 公式按章节编号
 \renewcommand{\thefigure}{\thesection.\arabic{figure}}  % 图几.几
 \renewcommand{\thetable}{\thesection-\arabic{table}}  % 表几-几
-
+% 公式按照一级标题开始编号 (1.x) 表示第一章里面得公式 x
+\renewcommand{\theequation}{\thesection-\arabic{equation}} % 设置公式编号格式
 % 增大表格间距
 % \renewcommand{\arraystretch}{1.2}
 


### PR DESCRIPTION
1. 目录只需要数字编号即可，注释掉了[cls第72行](https://github.com/zb-zombie/A-CSUST-Bachelor-thesis-template-based-on-LaTeX-system/blob/ff97a63bfd5671fbe8ae97f1da013526f28c09d1/csustThesis.cls#L72)，这样才符合2023年的毕业论文要求。  
2. 公式按照 一级标题 `\section`编号为 1.x。
3. 原本的参考文献格式 [this](https://github.com/zb-zombie/A-CSUST-Bachelor-thesis-template-based-on-LaTeX-system/blob/ff97a63bfd5671fbe8ae97f1da013526f28c09d1/csustThesis.cls#L29) 符合`gb7714-2015`，但是学院的要求和它略有出入，参考文献中不能出现 `[S.I.][s.n.]`和`\\`，所以加入了`gbpunctin=false,gbpub=false`选项后，符合学院要求。
4. 对于分享，学校要求：一级分项用`(1) (2)`编号，二级分项用`①`开头，故引入了宏包 `pifont`，并且写了一个指令可以控制 ① 的大小。虽然用 `enumitem` 或许可能可以实现这个需求，但是使用 `enumerate`环境时，发现对缩进并不太友好，所以我选择手动编号，手动缩进以满足学院的格式要求。
![image](https://github.com/zb-zombie/A-CSUST-Bachelor-thesis-template-based-on-LaTeX-system/assets/53985742/31a70499-b549-4b60-a0fa-76bedd41ceec)
