### PR TITLE
Provide option for single line title.

### DIFF
--- a/baseinfo.tex
+++ b/baseinfo.tex
@@ -2,10 +2,11 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 通用基本信息 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \thesisTitle
-{基于 \LaTeX 系统的长沙理工大学\\本科生毕业论文模板}  % 论文题目
+{基于 \LaTeX 系统的长沙理工大学\\本科生毕业论文模板}  % 论文题目，使用\\断行
 {A CSUST Bachelor thesis template\\based on \LaTeX{} system} % 论文英文题目，英文摘要用
 
 \thesisCompleteTime{\the\year}{\the\month}{9} % 论文完成时间，依次填写年、月、日
+% \singleLineTitle  % “题目”一栏默认显示两条横线，若要隐藏第二条横线，请取消该行注释。
 
 \stuName{XXX} % 学生姓名
 

--- a/csustThesis.cls
+++ b/csustThesis.cls
@@ -208,6 +208,10 @@
     \def\csustThesis@title{#1}
     \def\csustThesis@entitle{#2}
 }
+\newcommand{\csustThesis@title@secunderline}[1]{\underline{#1}}
+\newcommand{\singleLineTitle}{
+    \def\csustThesis@title@secunderline{}
+}
 
 % 论文完成时间
 \newcommand{\csustThesis@completeYear}{}
@@ -332,7 +336,7 @@
         \settowidth{\maxwidth}{题目：}
         \makebox[\maxwidth][s]{题目：}\underline{\makebox[\titleBoxLen][l]{\phantom{幻影}}}
     
-        \hspace*{\maxwidth}\underline{\makebox[\titleBoxLen][l]{\phantom{幻影}}}
+        \hspace*{\maxwidth}\csustThesis@title@secunderline{\makebox[\titleBoxLen][l]{\phantom{幻影}}}
 
         \vspace*{-2\baselineskip}  % 2.78cm
         \hspace*{\maxwidth}
@@ -546,7 +550,7 @@
         \settowidth{\maxwidth}{题目：}
         \makebox[\maxwidth][s]{题目：}\underline{\makebox[\titleBoxLen][c]{\phantom{幻影}}}
     
-        \hspace*{\maxwidth}\underline{\makebox[\titleBoxLen][l]{\phantom{幻影}}}
+        \hspace*{\maxwidth}\csustThesis@title@secunderline{\makebox[\titleBoxLen][l]{\phantom{幻影}}}
 
         \vspace*{-2\baselineskip}
         \hspace*{\maxwidth}

--- a/csustThesis.cls
+++ b/csustThesis.cls
@@ -624,7 +624,7 @@
         \zihao{4}
         \makebox[\maxwidth][l]{题\hspace{1.5em}目}\underline{\makebox[10cm][c]{\phantom{幻影}}}
     
-        \hspace*{\maxwidth}\underline{\makebox[10cm][l]{\phantom{幻影}}}
+        \hspace*{\maxwidth}\csustThesis@title@secunderline{\makebox[10cm][l]{\phantom{幻影}}}
 
         \vspace*{-2\baselineskip}
         \hspace*{\maxwidth}


### PR DESCRIPTION
#6 
- “题目”一栏默认显示两条横线。
- 新增 `\singleLineTitle` 命令以供选择隐藏第二条线。（根据内容自动增加感觉不是很有必要）